### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,7 @@ project_urls =
     Bug Tracker = https://github.com/matyifkbt/pysteammarket/issues
     Changelog = https://github.com/matyifkbt/pysteammarket/blob/master/CHANGELOG.md
 
+description-file = docs.md
+
 [bumpversion]
 current_version = 1.1.1
-
-[metadata]
-description-file = docs.md


### PR DESCRIPTION
I was unable to setup module cause of 
```configparser.DuplicateSectionError: While reading from 'setup.cfg' [line  9]: section 'metadata' already exists ``` error

and moved ```description-file = docs.md``` to the first [metadata] block